### PR TITLE
doctrine/cache interface compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "doctrine/cache": "1.3.*"
+        "doctrine/cache": ">=1.3"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "doctrine/cache": ">=1.3"
+        "doctrine/cache": "1.3.*||1.4.*"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
This library is compatible with [`doctrine/cache:v1.4`](https://github.com/doctrine/cache/blob/v1.4.0/lib/Doctrine/Common/Cache/Cache.php) too, so I added the `>=` operator to allow new versions without breaking changes.